### PR TITLE
set mandatory LF line endings for .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
There is an issue with Unix/Windows line endings. When working with this template on a Windows system git automatically  tranforms Unix line endings into Windows ones, causing the docker image building process to fail. This can be solved by specifying mandatory line endings in .gitattributes.

Ref: https://stackoverflow.com/questions/38905135/why-wont-my-docker-entrypoint-sh-execute